### PR TITLE
remove nose from the setup.py requirements so that pip install bottle-ss...

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,7 @@ setup(
   include_package_data=True,
   platforms='any',
   install_requires=[
-    'bottle==0.10.11',
-    'nose==1.2.1',
+    'bottle==0.10.11'
   ],
   classifiers=[
     'Environment :: Web Environment',


### PR DESCRIPTION
...lify does not automatically install nose
